### PR TITLE
minor bug: even if the public port changes, the container port is still 5000

### DIFF
--- a/minikube-with-registry.sh
+++ b/minikube-with-registry.sh
@@ -41,7 +41,7 @@ minikube start -p "$MINIKUBE_PROFILE_NAME" --driver=docker --container-runtime=c
 
 # patch the container runtime
 # this is the most annoying sed expression i've ever had to write
-minikube ssh sudo sed "\-i" "s,\\\[plugins.cri.registry.mirrors\\\],[plugins.cri.registry.mirrors]\\\n\ \ \ \ \ \ \ \ [plugins.cri.registry.mirrors.\\\"localhost:${reg_port}\\\"]\\\n\ \ \ \ \ \ \ \ \ \ endpoint\ =\ [\\\"http://${reg_host}:${reg_port}\\\"]," /etc/containerd/config.toml
+minikube ssh sudo sed "\-i" "s,\\\[plugins.cri.registry.mirrors\\\],[plugins.cri.registry.mirrors]\\\n\ \ \ \ \ \ \ \ [plugins.cri.registry.mirrors.\\\"localhost:${reg_port}\\\"]\\\n\ \ \ \ \ \ \ \ \ \ endpoint\ =\ [\\\"http://${reg_host}:5000\\\"]," /etc/containerd/config.toml
 
 # restart the container runtime
 minikube ssh sudo systemctl restart containerd


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ports:

9c86beb8a580445fc62e3cbf1d43d4efc2661215 (2020-10-23 17:27:44 -0400)
minor bug: even if the public port changes, the container port is still 5000
noticed this when playing with alternative host ports

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics